### PR TITLE
fix option types

### DIFF
--- a/lib/value.mli
+++ b/lib/value.mli
@@ -3,7 +3,8 @@ open Ppxlib
 
 val type_to_expr : core_type -> expression
 
-val record_to_expr : loc:Location.t -> label_declaration list -> expression
+val record_to_expr :
+  typ:core_type -> loc:Location.t -> label_declaration list -> expression
 
 val type_decl_to_type : type_declaration -> core_type
 

--- a/ppx/ppx_deriving_yaml.ml
+++ b/ppx/ppx_deriving_yaml.ml
@@ -47,7 +47,9 @@ let generate_impl ~ctxt (_rec_flag, type_decls) =
                    Vb.mk
                      (ppat_var ~loc { loc; txt = to_yaml })
                      (Helpers.poly_fun ~loc:ptype_loc typ_decl
-                        (Value.record_to_expr ~loc:ptype_loc fields));
+                        (Value.record_to_expr
+                           ~typ:(core_type_of_type_declaration typ_decl)
+                           ~loc:ptype_loc fields));
                  ];
                pstr_value ~loc Nonrecursive
                  [

--- a/test/test.ml
+++ b/test/test.ml
@@ -99,6 +99,32 @@ let test_simple_poly () =
   Alcotest.(check (result str_pol error))
     "(of_yaml) same polymorhpic record" (Ok correct_str_of) test_str_of
 
+type str_opt = { name : string option } [@@deriving yaml]
+
+let str_opt =
+  Alcotest.testable
+    (fun ppf x ->
+      match x.name with
+      | Some t -> Format.pp_print_string ppf t
+      | None -> Format.pp_print_string ppf "none")
+    Stdlib.( = )
+
+let test_option () =
+  let correct_opt_some = `O [ ("name", `String "Alice") ] in
+  let test_opt_some = str_opt_to_yaml { name = Some "Alice" } in
+  let correct_opt_none = `O [ ("name", `Null) ] in
+  let test_opt_none = str_opt_to_yaml { name = None } in
+  let correct_opt_some_of = Ok { name = Some "Alice" } in
+  let test_opt_some_of = str_of_yaml correct_opt_some in
+  let correct_opt_none_of = Ok { name = None } in
+  let test_opt_none_of = str_of_yaml correct_opt_none in
+  Alcotest.check yaml "same string option (some)" correct_opt_some test_opt_some;
+  Alcotest.check yaml "same string option (none)" correct_opt_none test_opt_none;
+  Alcotest.(check (result str_opt error))
+    "(of_yaml) same string option (some)" correct_opt_some_of test_opt_some_of;
+  Alcotest.(check (result str_opt error))
+    "(of_yaml) same string option (none)" correct_opt_none_of test_opt_none_of
+
 let tests : unit Alcotest.test_case list =
   [
     ("test_primitives", `Quick, test_primitives);


### PR DESCRIPTION
Things like `{ name : string option }` were incorrectly implemented -- this PR fixes them and adds tests. 