### PR TITLE
return none for missing options

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ produces the following function.
 val note_to_yaml : ('a -> Yaml.value) -> 'a note -> [> `O of (string * Yaml.value) list ]
 ```
 
+### Implementation Details 
+
+One important thing is that `'a option` values within records will return `None` if the Yaml you are trying to convert does not exist.
+
 ### Checklist 
 
 - [x] Simples types (`int, list, records...`) to `Yaml.value` types


### PR DESCRIPTION
By making a record field type optional the deriver will replace it with a `Ok None` rather than raising an error if the field does not exist within the Yaml data.

```ocaml
# type t = { name : string; nickname: string option } [@@deriving yaml]
# of_yaml (`O [("name", `String "Alice")]) 
:- Ok { name = "Alice"; nickname = None }
```

This makes it nice to use with optional fields in your Yaml metadata. 
