### PR TITLE
Variants

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         ocaml-version: ${{ matrix.ocaml-version }}
     - run: opam pin add ppx_deriving_yaml.dev -n .
     - name: Packages
-      run: opam depext -yt ppx_deriving_yaml
+      run: opam depext -y ppx_deriving_yaml
     - name: Dependencies
       run: opam install -t . --deps-only
     - name: Build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Ppx_deriving_yaml -- OCaml types to YAML types 
 
-This ppx is based on [ppx_yojson](https://github.com/NathanReb/ppx_yojson) and [ppx_deriving_yojson](https://github.com/ocaml-ppx/ppx_deriving_yojson) because of the many similarities between json and yaml.
+This ppx is based on [ppx_yojson](https://github.com/NathanReb/ppx_yojson) and [ppx_deriving_yojson](https://github.com/ocaml-ppx/ppx_deriving_yojson) because of the many similarities between json and yaml. In particular many of the semantics of OCaml types <-> Yaml types are the same as those implemented by the Yojson ppx.
 
 This is a small ppx deriver that lets you convert your OCaml types to [yaml](https://github.com/avsm/ocaml-yaml) ones. This means you can describe yaml structures in OCaml and easily convert them to yaml.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,6 @@ One important thing is that `'a option` values within records will return `None`
 - [x] `Yaml.value` interface types 
 - [x] `Yaml.value` types to OCaml types i.e. `of_yaml` 
 - [x] More complex types (parametric polymorphic ones) to any of the Yaml types 
-- [ ] Design and implement how variants should be handled
+- [x] Design and implement how variants should be handled
 - [ ] Better interface support i.e. `.mli` files 
 - [ ] Simple types (`int, list, records...`) to `Yaml.yaml` types

--- a/lib/helpers.ml
+++ b/lib/helpers.ml
@@ -1,6 +1,8 @@
 open Ppxlib
 open Ast_helper
 
+let arg n = "arg" ^ string_of_int n
+
 let mkloc txt = { txt; loc = !Ast_helper.default_loc }
 
 let suf_to = "to_yaml"

--- a/lib/helpers.mli
+++ b/lib/helpers.mli
@@ -2,6 +2,8 @@ open Ppxlib
 
 val mkloc : 'a -> 'a Ppxlib.loc
 
+val arg : int -> string
+
 val suf_to : string
 
 val suf_of : string

--- a/lib/value.mli
+++ b/lib/value.mli
@@ -12,3 +12,8 @@ val of_yaml_type_to_expr : string option -> core_type -> expression
 
 val of_yaml_record_to_expr :
   loc:Location.t -> label_declaration list -> expression
+
+val monad_fold :
+  ('a -> expression) -> expression -> ('a * int) list -> expression
+
+val wrap_open_rresult : loc:location -> expression -> expression

--- a/test/test.ml
+++ b/test/test.ml
@@ -146,12 +146,37 @@ let test_option () =
   Alcotest.(check (result str_opt error))
     "(of_yaml) same string option (none)" correct_opt_none_of test_opt_none_of
 
+type poly_var = [ `Alpha | `Beta of int * string ] [@@deriving yaml]
+
+let poly_var =
+  Alcotest.testable
+    (fun ppf -> function `Alpha -> Fmt.pf ppf "Alpha"
+      | `Beta (i, s) -> Fmt.pf ppf "Beta (%i, %s)" i s)
+    Stdlib.( = )
+
+let test_poly_variants () =
+  let correct_yaml_a = `O [ ("Alpha", `A []) ] in
+  let test_yaml_a = poly_var_to_yaml `Alpha in
+  let correct_yaml_b = `O [ ("Beta", `A [ `Float 3.; `String "hello" ]) ] in
+  let test_yaml_b = poly_var_to_yaml (`Beta (3, "hello")) in
+  let correct_yaml_a_of = Ok `Alpha in
+  let test_yaml_a_of = poly_var_of_yaml correct_yaml_a in
+  let correct_yaml_b_of = Ok (`Beta (3, "hello")) in
+  let test_yaml_b_of = poly_var_of_yaml correct_yaml_b in
+  Alcotest.check yaml "same polymorphic variant" correct_yaml_a test_yaml_a;
+  Alcotest.check yaml "same polymorphic variant" correct_yaml_b test_yaml_b;
+  Alcotest.(check (result poly_var error))
+    "(of_yaml) same polymorphic variant" correct_yaml_a_of test_yaml_a_of;
+  Alcotest.(check (result poly_var error))
+    "(of_yaml) same polymorphic variant" correct_yaml_b_of test_yaml_b_of
+
 let tests : unit Alcotest.test_case list =
   [
     ("test_primitives", `Quick, test_primitives);
     ("test_record_list", `Quick, test_record_list);
     ("test_tuple", `Quick, test_tuple);
     ("test_simple_poly", `Quick, test_simple_poly);
+    ("test_poly_variants", `Quick, test_poly_variants);
   ]
 
-let () = Alcotest.run "PPX Deriving Yaml" [ ("ppx", tests) ]
+let () = Alcotest.run "PPX_Deriving_Yaml" [ ("ppx", tests) ]


### PR DESCRIPTION
This PR adds converting variants (normal & polymorphic) to Yaml and back. The design decision was to make them an object. 

```ocaml
type t = Camel of int * string

let v = Camel (3, "A")
let yaml_repr = `O [("Camel", `A [`Int 3; `String "A"])]
```