### PR TITLE
use attributes for variants and records

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,24 @@ One important thing is that `'a option` values within records will return `None`
 | `record` e.g `{ name : string }` |  `` `O [("name", `String s)] `` |
 |  `A of int` or `` [`A of int]``  | `` `O [("A", `A [`Float f])] `` |
 
+### Optional Attributes 
+
+OCaml has constraints on the shape that certain words in the syntax can take. For example, record field names cannot begin with a capital letter and variant constructors must start with one. This limits what the generated yaml can look like. To override the yaml names you can use the `[@key <string>]` and `[@name <string>]` attributes for records and variants respectively. 
+
+For example: 
+
+```ocaml
+type t = {
+  camel_name : string [@key "camel-name"]
+}
+```
+
+Will produce Yaml of the form 
+
+```yaml
+camel-name: <string>
+```
+
 ### Checklist 
 
 - [x] Simples types (`int, list, records...`) to `Yaml.value` types

--- a/lib/attrs.ml
+++ b/lib/attrs.ml
@@ -1,0 +1,14 @@
+open Ppxlib
+let key =
+  Attribute.declare
+    "yaml.key"
+    Attribute.Context.label_declaration
+    Ast_pattern.(pstr (pstr_eval (estring __) nil ^:: nil))
+    (fun x -> x)
+
+    let name =
+      Attribute.declare
+        "yaml.name"
+        Attribute.Context.constructor_declaration
+        Ast_pattern.(pstr (pstr_eval (estring __) nil ^:: nil))
+        (fun x -> x)

--- a/lib/attrs.mli
+++ b/lib/attrs.mli
@@ -1,0 +1,4 @@
+open Ppxlib 
+
+val key : (label_declaration, label) Attribute.t
+val name : (constructor_declaration, string) Attribute.t

--- a/test/test.ml
+++ b/test/test.ml
@@ -211,6 +211,35 @@ let test_poly_variants () =
   Alcotest.(check (result poly_var error))
     "(of_yaml) same polymorphic variant" correct_yaml_c_of test_yaml_c_of
 
+(** Attributes *)
+type vattrib = Camel of int [@name "camel"] [@@deriving yaml]
+
+type rattrib = { camel_name : string [@key "camel-name"] } [@@deriving yaml]
+
+let vattrib =
+  Alcotest.testable (fun ppf (Camel i) -> Fmt.int ppf i) Stdlib.( = )
+
+let rattrib =
+  Alcotest.testable
+    (fun ppf v -> Fmt.pf ppf "{ camel-name: %s }" v.camel_name)
+    Stdlib.( = )
+
+let test_attrib () =
+  let correct_yaml_v = `O [ ("camel", `A [ `Float 1. ]) ] in
+  let test_yaml_v = vattrib_to_yaml (Camel 1) in
+  let correct_yaml_r = `O [ ("camel-name", `String "lawrence") ] in
+  let test_yaml_r = rattrib_to_yaml { camel_name = "lawrence" } in
+  let correct_yaml_v_of = Ok (Camel 1) in
+  let test_yaml_v_of = vattrib_of_yaml correct_yaml_v in
+  let correct_yaml_r_of = Ok { camel_name = "lawrence" } in
+  let test_yaml_r_of = rattrib_of_yaml correct_yaml_r in
+  Alcotest.check yaml "same variant" correct_yaml_v test_yaml_v;
+  Alcotest.check yaml "same record" correct_yaml_r test_yaml_r;
+  Alcotest.(check (result vattrib error))
+    "(of_yaml) same variant" correct_yaml_v_of test_yaml_v_of;
+  Alcotest.(check (result rattrib error))
+    "(of_yaml) same record" correct_yaml_r_of test_yaml_r_of
+
 let tests : unit Alcotest.test_case list =
   [
     ("test_primitives", `Quick, test_primitives);
@@ -219,6 +248,7 @@ let tests : unit Alcotest.test_case list =
     ("test_simple_poly", `Quick, test_simple_poly);
     ("test_var", `Quick, test_var);
     ("test_poly_variants", `Quick, test_poly_variants);
+    ("test_attrib", `Quick, test_attrib);
   ]
 
 let () = Alcotest.run "PPX_Deriving_Yaml" [ ("ppx", tests) ]


### PR DESCRIPTION
Adds attribute values for changing record field names and constructor names. Fixes #8 