### PR TITLE
Of yaml mli

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,5 +83,5 @@ camel-name: <string>
 - [x] `Yaml.value` types to OCaml types i.e. `of_yaml` 
 - [x] More complex types (parametric polymorphic ones) to any of the Yaml types 
 - [x] Design and implement how variants should be handled
-- [ ] Better interface support i.e. `.mli` files 
+- [x] Better interface support i.e. `.mli` files 
 - [ ] Simple types (`int, list, records...`) to `Yaml.yaml` types

--- a/lib/value.mli
+++ b/lib/value.mli
@@ -8,6 +8,8 @@ val record_to_expr :
 
 val type_decl_to_type : type_declaration -> core_type
 
+val type_decl_of_type : type_declaration -> core_type
+
 val of_yaml_type_to_expr : string option -> core_type -> expression
 
 val of_yaml_record_to_expr :

--- a/ppx/ppx_deriving_yaml.ml
+++ b/ppx/ppx_deriving_yaml.ml
@@ -173,15 +173,27 @@ let generate_intf ~ctxt (_rec_flag, type_decls) : Ppxlib.Ast.signature_item list
     (fun typ_decl ->
       match typ_decl with
       | { ptype_kind = Ptype_abstract | Ptype_record _; _ } ->
-          psig_value ~loc
-            (Val.mk
-               {
-                 loc = typ_decl.ptype_name.loc;
-                 txt = mangle_name_label Helpers.suf_to typ_decl.ptype_name.txt;
-               }
-               (Value.type_decl_to_type typ_decl))
+          [
+            psig_value ~loc
+              (Val.mk
+                 {
+                   loc = typ_decl.ptype_name.loc;
+                   txt =
+                     mangle_name_label Helpers.suf_to typ_decl.ptype_name.txt;
+                 }
+                 (Value.type_decl_to_type typ_decl));
+            psig_value ~loc
+              (Val.mk
+                 {
+                   loc = typ_decl.ptype_name.loc;
+                   txt =
+                     mangle_name_label Helpers.suf_of typ_decl.ptype_name.txt;
+                 }
+                 (Value.type_decl_of_type typ_decl));
+          ]
       | _ -> Location.raise_errorf ~loc "Cannot derive anything for this type")
     type_decls
+  |> List.concat
 
 let impl_generator =
   Deriving.Generator.V2.make_noarg


### PR DESCRIPTION
This PR adds the `of_yaml` type signature to `.mli` files -- fixes #10 