### PR TITLE
Fix rresult transitive dependency issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## v0.1.1
+
+- Remove rresult dependency (#27, @patricoferris)
+
 ## v0.1.0
 
 - Initial public release

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For converting OCaml types to Yaml types `ppx_deriving_yaml` will do the convent
 
 `to_yaml` produces a [`Yaml.value`](https://github.com/avsm/ocaml-yaml/blob/master/lib/types.ml#L44) which is compatible with the [`Ezjsonm.value`](https://github.com/mirage/ezjsonm/blob/master/lib/ezjsonm.ml#L18) type. 
 
-`of_yaml` produces OCaml types wrapped in a `Rresult.R.t` -- this is how ocaml-yaml also handles errors i.e. not using exceptions. Based on your type this should let you move between yaml and OCaml types.
+`of_yaml` produces OCaml types wrapped in a `result` -- this is how ocaml-yaml also handles errors i.e. not using exceptions. Based on your type this should let you move between yaml and OCaml types.
 
 Here is a small example. 
 

--- a/dune-project
+++ b/dune-project
@@ -11,7 +11,7 @@
 
 (authors "Patrick Ferris")
 
-(maintainers "pf341@patricoferris.com")
+(maintainers "patrick@sirref.org")
 
 (package
  (name ppx_deriving_yaml)
@@ -26,7 +26,6 @@
    (>= 4.08.1))
   (ppxlib
    (>= 0.14.0))
-  yaml
-  rresult))
+  yaml))
 
 (using mdx 0.1)

--- a/lib/value.ml
+++ b/lib/value.ml
@@ -155,7 +155,7 @@ let type_decl_of_type type_decl =
 
 let wrap_open_rresult ~loc expr =
   [%expr
-    let open! Rresult.R.Infix in
+    let ( >>= ) v f = match v with Ok v -> f v | Error _ as e -> e in
     [%e expr]]
 
 let mk_pat_match ~loc cases =
@@ -200,7 +200,7 @@ let rec of_yaml_type_to_expr name typ =
         [
           ( [%pat? `A lst],
             [%expr
-              let open! Rresult.R.Infix in
+              let ( >>= ) v f = match v with Ok v -> f v | Error _ as e -> e in
               [%e Helpers.map_bind ~loc] [%e of_yaml_type_to_expr None typ] lst]
           );
         ]
@@ -209,7 +209,7 @@ let rec of_yaml_type_to_expr name typ =
         [
           ( [%pat? `A lst],
             [%expr
-              let open! Rresult.R.Infix in
+              let ( >>= ) v f = match v with Ok v -> f v | Error _ as e -> e in
               `A
                 Array.(
                   to_list ([%e Helpers.map_bind ~loc] [%e type_to_expr typ]))]

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -1,1 +1,0 @@
-(** {1 Functions for converting OCaml types to Yaml.yaml types} *)

--- a/ppx_deriving_yaml.opam
+++ b/ppx_deriving_yaml.opam
@@ -2,7 +2,7 @@
 opam-version: "2.0"
 synopsis: "Yaml PPX Derivier"
 description: "Build Yaml types from OCaml types"
-maintainer: ["pf341@patricoferris.com"]
+maintainer: ["patrick@sirref.org"]
 authors: ["Patrick Ferris"]
 license: "ISC"
 homepage: "https://github.com/patricoferris/ppx_deriving_yaml"
@@ -16,7 +16,6 @@ depends: [
   "ocaml" {>= "4.08.1"}
   "ppxlib" {>= "0.14.0"}
   "yaml"
-  "rresult"
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
This PR removes the use of `Rresult` -- it was being transitively brought in by older yaml versions but that was removed in https://github.com/avsm/ocaml-yaml/pull/50