### PR TITLE
Improved error messaging

### DIFF
--- a/test/expect/passing/simple.expected
+++ b/test/expect/passing/simple.expected
@@ -19,7 +19,12 @@ include
             match xs with
             | ("name", x)::xs ->
                 loop xs
-                  (((function | `String x -> Ok x | _ -> Error (`Msg "err"))
+                  (((function
+                     | `String x -> Ok x
+                     | _ ->
+                         Error
+                           (`Msg
+                              "Was expecting 'string' but got a different type"))
                       x), arg1)
             | ("age", x)::xs ->
                 loop xs
@@ -29,8 +34,12 @@ include
                       | x ->
                           ((function
                             | `Float x -> Ok (int_of_float x)
-                            | _ -> Error (`Msg "err")) x) >>=
-                            ((fun x -> Ok (Some x)))) x))
+                            | _ ->
+                                Error
+                                  (`Msg
+                                     "Was expecting 'int' but got a different type"))
+                             x)
+                            >>= ((fun x -> Ok (Some x)))) x))
             | [] ->
                 arg1 >>=
                   ((fun arg1 ->


### PR DESCRIPTION
Hi @patricoferris @pitag-ha @ayc9. Hope you all are having a great week.

Concerning this issue, I used some strings to indicate the expected type, then passed it to the error message. Please kindly review if I got it correctly. I am still working to get the user input type and also to tell the user the key that generated the error.

I also removed the unnecessary line in the ```option_to_none``` function @pitag-ha pointed out...