### PR TITLE
Hide record fields with default values in `to_yaml` output

### DIFF
--- a/test/expect/passing/simple.expected
+++ b/test/expect/passing/simple.expected
@@ -5,12 +5,14 @@ include
   struct
     let to_yaml (x : t) =
       `O
-        [("name", (((fun (x : string) -> `String x)) x.name));
-        ("age",
-          (((function
-             | None -> `Null
-             | Some t -> ((fun (x : int) -> `Float (float_of_int x))) t))
-             x.age))]
+        (List.filter_map (fun x -> x)
+           [Some ("name", (((fun (x : string) -> `String x)) x.name));
+           Some
+             ("age",
+               (((function
+                  | None -> `Null
+                  | Some t -> ((fun (x : int) -> `Float (float_of_int x))) t))
+                  x.age))])
     let of_yaml =
       let (>>=) v f = match v with | Ok v -> f v | Error _ as e -> e in
       function
@@ -56,7 +58,13 @@ type u = {
 include
   struct
     let u_to_yaml (x : u) =
-      `O [("name", (((fun (x : string) -> `String x)) x.name))]
+      `O
+        (List.filter_map (fun x -> x)
+           [((fun x ->
+                if x = "Una"
+                then None
+                else Some ("name", (((fun (x : string) -> `String x)) x))))
+              x.name])
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type v = {
   age: int [@key "AGE"][@default 10]}[@@deriving of_yaml]

--- a/test/test.ml
+++ b/test/test.ml
@@ -66,7 +66,7 @@ let test_record_list () =
         ( "db",
           `A
             [
-              `O [ ("name", `String "Alice"); ("age", `Float 20.) ];
+              `O [ ("age", `Float 20.) ];
               `O [ ("name", `String "Bob"); ("age", `Float 21.) ];
             ] );
       ]


### PR DESCRIPTION
This modifies the `to_yaml` function to take into account the `[@default]` attribute of record fields. If the field value is equal (`=`) to the default value, then it is omitted from the YAML object as proposed in #35.

I can see how this is useful for `'a option` fields with default `None`. But I can imagine that for other types/scenarios this behavior is less useful than the current one. Maybe the library could let the user decide by including an optional argument in `to_yaml`, e.g.

```ocaml
val person_to_yaml : ?include_defaults:bool -> person -> Yaml.value 
```

Just a thought. If you have any feedback/suggestions on the implementation I am happy to iterate on it.