### PR TITLE
Fix skip unknown

### DIFF
--- a/src/value.ml
+++ b/src/value.ml
@@ -431,7 +431,7 @@ let of_yaml_record_to_expr ~loc ~skip_unknown fields =
     kv_cases
     @ [
         Exp.case [%pat? []] base_case;
-        (if skip_unknown then Exp.case [%pat? _] base_case
+        (if skip_unknown then Exp.case [%pat? _ :: xs] [%expr loop xs _state]
         else
           Exp.case
             [%pat? (x, y) :: _]

--- a/test/expect/passing/skip_unknown.expected
+++ b/test/expect/passing/skip_unknown.expected
@@ -32,10 +32,7 @@ include
                 arg1 >>=
                   ((fun arg1 ->
                       arg0 >>= (fun arg0 -> Ok { name = arg0; age = arg1 })))
-            | _ ->
-                arg1 >>=
-                  ((fun arg1 ->
-                      arg0 >>= (fun arg0 -> Ok { name = arg0; age = arg1 }))) in
+            | _::xs -> loop xs _state in
           loop xs
             ((Error (`Msg "Didn't find the function for key: name")),
               (Error (`Msg "Didn't find the function for key: age")))


### PR DESCRIPTION
In the current buggy implementation, when we encounter an unknown key, we just return the base-case as if there's no need to loop further, so the logic is incorrect. If you try anything other than the trivial example where the unknown field (that we're skipping) occurs at the end. This PR fixes it so that it does the more sane thing and loops over the remainder of the list.