### PR TITLE
Handle recursive types

### DIFF
--- a/test/expect/passing/dune.inc
+++ b/test/expect/passing/dune.inc
@@ -1,3 +1,35 @@
+; -------- Test: `recursive.ml` --------
+
+; The PPX-dependent executable under test
+(executable
+ (name recursive)
+ (modules recursive)
+ (preprocess (pps ppx_deriving_yaml))
+ (libraries yaml))
+
+; Run the PPX on the `.ml` file
+(rule
+ (targets recursive.actual)
+ (deps
+  (:pp pp.exe)
+  (:input recursive.ml))
+ (action
+  (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
+
+; Compare the post-processed output to the .expected file
+(rule
+ (alias runtest)
+ (package ppx_deriving_yaml)
+ (action
+  (diff recursive.expected recursive.actual)))
+
+; Ensure that the post-processed executable runs correctly
+(rule
+ (alias runtest)
+ (package ppx_deriving_yaml)
+ (action
+  (run ./recursive.exe)))
+
 ; -------- Test: `simple.ml` --------
 
 ; The PPX-dependent executable under test

--- a/test/expect/passing/recursive.expected
+++ b/test/expect/passing/recursive.expected
@@ -1,0 +1,63 @@
+type t = {
+  name: string ;
+  children: t list }[@@deriving yaml]
+include
+  struct
+    let rec to_yaml (x : t) =
+      `O
+        (List.filter_map (fun x -> x)
+           [Some ("name", (((fun (x : string) -> `String x)) x.name));
+           Some
+             ("children",
+               (((fun x -> `A (List.map (fun x -> to_yaml x) x))) x.children))])
+    let rec of_yaml =
+      let (>>=) v f = match v with | Ok v -> f v | Error _ as e -> e in
+      function
+      | `O xs ->
+          let rec loop xs ((arg0, arg1) as _state) =
+            match xs with
+            | ("name", x)::xs ->
+                loop xs
+                  (((function
+                     | `String x -> Ok x
+                     | _ ->
+                         Error
+                           (`Msg
+                              "Was expecting 'string' but got a different type"))
+                      x), arg1)
+            | ("children", x)::xs ->
+                loop xs
+                  (arg0,
+                    ((function
+                      | `A lst ->
+                          let (>>=) v f =
+                            match v with | Ok v -> f v | Error _ as e -> e in
+                          ((fun f ->
+                              fun lst ->
+                                (List.fold_left
+                                   (fun acc ->
+                                      fun x ->
+                                        match acc with
+                                        | Ok acc ->
+                                            (f x) >>=
+                                              ((fun x -> Ok (x :: acc)))
+                                        | Error e -> Error e) (Ok []) lst)
+                                  >>= (fun lst -> Ok (List.rev lst))))
+                            (fun x -> of_yaml x) lst
+                      | _ ->
+                          Error
+                            (`Msg
+                               "Was expecting 'list' but got a different type"))
+                       x))
+            | [] ->
+                arg1 >>=
+                  ((fun arg1 ->
+                      arg0 >>=
+                        (fun arg0 -> Ok { name = arg0; children = arg1 })))
+            | (x, y)::_ -> Error (`Msg (x ^ (Yaml.to_string_exn y))) in
+          loop xs
+            ((Error (`Msg "Didn't find the function for key: name")),
+              (Error (`Msg "Didn't find the function for key: children")))
+      | _ ->
+          Error (`Msg "Failed building a key-value object expecting a list")
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]

--- a/test/expect/passing/recursive.ml
+++ b/test/expect/passing/recursive.ml
@@ -1,0 +1,1 @@
+type t = { name : string; children : t list } [@@deriving yaml]

--- a/test/test.ml
+++ b/test/test.ml
@@ -263,6 +263,18 @@ let test_unknown () =
   let expected = Ok { name = "Bob"; age = 42 } in
   Alcotest.(check (result unknown error)) "same unknown" expected v
 
+type recursive = { name : string; children : recursive list } [@@deriving yaml]
+
+let recursive = Alcotest.of_pp (fun ppf v -> Yaml.pp ppf (recursive_to_yaml v))
+
+let test_recursive () =
+  let yaml = "name: Bob\nchildren:\n  - name: Alice\n    children: []\n" in
+  let v = Yaml.of_string_exn yaml |> recursive_of_yaml in
+  let expected =
+    Ok { name = "Bob"; children = [ { name = "Alice"; children = [] } ] }
+  in
+  Alcotest.(check (result recursive error)) "same unknown" expected v
+
 let tests : unit Alcotest.test_case list =
   [
     ("test_primitives", `Quick, test_primitives);
@@ -273,6 +285,7 @@ let tests : unit Alcotest.test_case list =
     ("test_poly_variants", `Quick, test_poly_variants);
     ("test_attrib", `Quick, test_attrib);
     ("test_unknown", `Quick, test_unknown);
+    ("test_recursive", `Quick, test_recursive);
   ]
 
 let () = Alcotest.run "ppx_deriving_yaml" [ ("ppx", tests) ]


### PR DESCRIPTION
Should fix #44 allowing users to get functions for types such as

```ocaml
type t = { name : string; children : t list } [@@deriving yaml]
```