### PR TITLE
Explicitly refer to stdlib modules in generated code

### DIFF
--- a/src/helpers.ml
+++ b/src/helpers.ml
@@ -54,10 +54,10 @@ let mangle_suf ?fixpoint suf lid =
 let map_bind ~loc =
   [%expr
     fun f lst ->
-      List.fold_left
+      Stdlib.List.fold_left
         (fun acc x ->
           match acc with
-          | Ok acc -> f x >>= fun x -> Ok (x :: acc)
-          | Error e -> Error e)
-        (Ok []) lst
-      >>= fun lst -> Ok (List.rev lst)]
+          | Stdlib.Ok acc -> f x >>= fun x -> Stdlib.Ok (x :: acc)
+          | Stdlib.Error e -> Stdlib.Error e)
+        (Stdlib.Ok []) lst
+      >>= fun lst -> Stdlib.Ok (Stdlib.List.rev lst)]

--- a/src/ppx_deriving_yaml.ml
+++ b/src/ppx_deriving_yaml.ml
@@ -89,7 +89,7 @@ let generate_impl_of_yaml ~ctxt (rec_flag, type_decls) skip_unknown =
                              monad_fold
                                (of_yaml_type_to_expr None)
                                [%expr
-                                 Result.Ok
+                                 Stdlib.Result.Ok
                                    [%e
                                      Exp.construct
                                        {
@@ -113,7 +113,7 @@ let generate_impl_of_yaml ~ctxt (rec_flag, type_decls) skip_unknown =
                          Exp.case
                            [%pat? _]
                            [%expr
-                             Error (`Msg "no match for this variant expression")];
+                             Stdlib.Error (`Msg "no match for this variant expression")];
                        ])
              in
              let of_yaml_expr =
@@ -175,7 +175,7 @@ let generate_impl_to_yaml ~ctxt (rec_flag, type_decls) =
              | Some t ->
                  let yamliser =
                    Helpers.poly_fun ~loc:typ_decl.ptype_loc typ_decl
-                     [%expr [%e Value.type_to_expr t]]
+                     (Value.type_to_expr t)
                  in
                  let to_yaml = mangle_name_label suf_to ptype_name.txt in
                  [

--- a/src/value.ml
+++ b/src/value.ml
@@ -178,7 +178,7 @@ let record_to_expr ~typ ~loc fields =
   let fs = fields_to_expr fields in
   [%expr
     fun (x : [%t typ]) ->
-      `O (List.filter_map (fun x -> x) [%e Ast_builder.Default.elist ~loc fs])]
+      `O (Stdlib.List.filter_map (fun x -> x) [%e Ast_builder.Default.elist ~loc fs])]
 
 let type_decl_to_type type_decl =
   let loc = type_decl.ptype_loc in
@@ -333,7 +333,7 @@ let rec of_yaml_type_to_expr name typ =
               [%e t] [%e evar ~loc (arg i)] >>= fun [%p pvar ~loc (arg i)] ->
               [%e acc]])
           [%expr
-            Result.Ok
+            Stdlib.Result.Ok
               [%e
                 Helpers.etuple ~loc
                   (List.mapi (fun i _ -> evar ~loc (arg i)) typs)]]
@@ -348,13 +348,13 @@ let rec of_yaml_type_to_expr name typ =
             | Rtag (name, true, []) ->
                 Exp.case
                   [%pat? `O [ ([%p pstring ~loc name.txt], `A []) ]]
-                  [%expr Result.Ok [%e Exp.variant name.txt None]]
+                  [%expr Stdlib.Result.Ok [%e Exp.variant name.txt None]]
             | Rtag (name, false, [ { ptyp_desc = Ptyp_tuple typs; _ } ]) ->
                 let e =
                   monad_fold
                     (of_yaml_type_to_expr None)
                     [%expr
-                      Result.Ok
+                      Stdlib.Result.Ok
                         [%e
                           Exp.variant name.txt
                             (Some
@@ -381,7 +381,7 @@ let rec of_yaml_type_to_expr name typ =
                   [%pat? `O [ ([%p pstring ~loc name.txt], `A [ x ]) ]]
                   [%expr
                     [%e of_yaml_type_to_expr None t] x >>= fun x ->
-                    Result.Ok [%e Exp.variant name.txt (Some (evar ~loc "x"))]]
+                    Stdlib.Result.Ok [%e Exp.variant name.txt (Some (evar ~loc "x"))]]
             | _ -> Exp.case [%pat? _] [%expr Error (`Msg "Not implemented")])
           row_fields
       in

--- a/test/expect/passing/recursive.expected
+++ b/test/expect/passing/recursive.expected
@@ -5,7 +5,7 @@ include
   struct
     let rec to_yaml (x : t) =
       `O
-        (List.filter_map (fun x -> x)
+        (Stdlib.List.filter_map (fun x -> x)
            [Some ("name", (((fun (x : string) -> `String x)) x.name));
            Some
              ("children",
@@ -34,15 +34,17 @@ include
                             match v with | Ok v -> f v | Error _ as e -> e in
                           ((fun f ->
                               fun lst ->
-                                (List.fold_left
+                                (Stdlib.List.fold_left
                                    (fun acc ->
                                       fun x ->
                                         match acc with
-                                        | Ok acc ->
+                                        | Stdlib.Ok acc ->
                                             (f x) >>=
-                                              ((fun x -> Ok (x :: acc)))
-                                        | Error e -> Error e) (Ok []) lst)
-                                  >>= (fun lst -> Ok (List.rev lst))))
+                                              ((fun x -> Stdlib.Ok (x :: acc)))
+                                        | Stdlib.Error e -> Stdlib.Error e)
+                                   (Stdlib.Ok []) lst)
+                                  >>=
+                                  (fun lst -> Stdlib.Ok (Stdlib.List.rev lst))))
                             (fun x -> of_yaml x) lst
                       | _ ->
                           Error

--- a/test/expect/passing/simple.expected
+++ b/test/expect/passing/simple.expected
@@ -5,7 +5,7 @@ include
   struct
     let to_yaml (x : t) =
       `O
-        (List.filter_map (fun x -> x)
+        (Stdlib.List.filter_map (fun x -> x)
            [Some ("name", (((fun (x : string) -> `String x)) x.name));
            Some
              ("age",
@@ -59,7 +59,7 @@ include
   struct
     let u_to_yaml (x : u) =
       `O
-        (List.filter_map (fun x -> x)
+        (Stdlib.List.filter_map (fun x -> x)
            [((fun x ->
                 if x = "Una"
                 then None
@@ -98,7 +98,7 @@ include
   struct
     let w_to_yaml (x : w) =
       `O
-        (List.filter_map (fun x -> x)
+        (Stdlib.List.filter_map (fun x -> x)
            [Some ("age", (((fun i -> `Float (float_of_int (i - 10)))) x.age))])
     let w_of_yaml =
       let (>>=) v f = match v with | Ok v -> f v | Error _ as e -> e in
@@ -132,7 +132,7 @@ include
   struct
     let x_to_yaml (x : x) =
       `O
-        (List.filter_map (fun x -> x)
+        (Stdlib.List.filter_map (fun x -> x)
            [Some
               ("age", (((fun (x : int) -> `Float (float_of_int x))) x.age))])
     let x_of_yaml =


### PR DESCRIPTION
This prevents incompat when deriving yaml is used in a scope with ContainersLabels, Base being open (which export functions with labelled arguments which conflict with the corresponding ones from Stdlib.*)
